### PR TITLE
Sedona & Spark 3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,9 +19,6 @@ LazyData: true
 Depends:
   R (>= 3.1.2)
 Imports:
-  sparklyr (>= 1.0.0),
-  dplyr (>= 0.8.3),
-  dbplyr (>= 1.3.0)
 RoxygenNote: 6.1.1
 Suggests:
   testthat, knitr, utils

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,9 @@ LazyData: true
 Depends:
   R (>= 3.1.2)
 Imports:
+  sparklyr (>= 1.0.0),
+  dplyr (>= 0.8.3),
+  dbplyr (>= 1.3.0)
 RoxygenNote: 6.1.1
 Suggests:
   testthat, knitr, utils

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,7 +1,7 @@
 spark_dependencies <- function(spark_version, scala_version, ...) {
   sparklyr::spark_dependency(
     packages = c(
-      paste0("org.apache.sedona:sedona-python-adapter-",spark_version,"_",scala_version,":1.0.0-incubating"),
+      paste0("org.apache.sedona:sedona-python-adapter-",spark_dependency_fallback(spark_version, c("3.0")),"_",scala_version,":1.0.0-incubating"),
       "org.datasyslab:geotools-wrapper:geotools-24.0"
     ),
     initializer = function(sc, ...) {

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,9 +1,8 @@
 spark_dependencies <- function(spark_version, scala_version, ...) {
   sparklyr::spark_dependency(
     packages = c(
-      paste0("org.apache.sedona:sedona-sql-3.0_2.12:1.0.0-incubating"),
-      "org.locationtech.jts:jts-core:1.18.0",
-      "org.apache.sedona:sedona-core-3.0_2.12:1.0.0-incubating"
+      paste0("org.apache.sedona:sedona-python-adapter-",spark_version,"_",scala_version,":1.0.0-incubating"),
+      "org.datasyslab:geotools-wrapper:geotools-24.0"
     ),
     initializer = function(sc, ...) {
       register_gis(sc)

--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -1,9 +1,9 @@
 spark_dependencies <- function(spark_version, scala_version, ...) {
   sparklyr::spark_dependency(
     packages = c(
-      paste0("org.datasyslab:geospark-sql_",sparklyr::spark_dependency_fallback(spark_version, c("2.1", "2.2", "2.3")),":1.3.1"),
-      "com.vividsolutions:jts-core:1.14.0",
-      "org.datasyslab:geospark:1.3.1"
+      paste0("org.apache.sedona:sedona-sql-3.0_2.12:1.0.0-incubating"),
+      "org.locationtech.jts:jts-core:1.18.0",
+      "org.apache.sedona:sedona-core-3.0_2.12:1.0.0-incubating"
     ),
     initializer = function(sc, ...) {
       register_gis(sc)

--- a/R/register_gis.R
+++ b/R/register_gis.R
@@ -18,6 +18,6 @@
 #' 
 #' @export
 register_gis <- function(sc) {
-    sparklyr::invoke_static(sc,"org.datasyslab.geosparksql.utils.GeoSparkSQLRegistrator","registerAll",spark_session(sc))
+    sparklyr::invoke_static(sc,"org.apache.sedona.sql.utils.SedonaSQLRegistrator","registerAll",spark_session(sc))
     return(invisible(sc))
 }

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -5,7 +5,7 @@
 # helper functions from sparklyr tests
 # https://github.com/rstudio/sparklyr/blob/master/tests/testthat/helper-initialize.R
 testthat_spark_connection <- function() {
-    version <- Sys.getenv("SPARK_VERSION", unset = "2.3.0")
+    version <- Sys.getenv("SPARK_VERSION", unset = "3.0.0")
     
     spark_installed <- sparklyr::spark_installed_versions()
     if (nrow(spark_installed[spark_installed$spark == version, ]) == 0) {


### PR DESCRIPTION
Putting this out there as a first attempt at adapting this wrapper to support Sedona and Spark 3.0 and to open a discussion on this topic.

This just updates the dependencies to reflect the advice [here](http://sedona.apache.org/download/GeoSpark-All-Modules-Maven-Central-Coordinates/#spark-30-scala-212).

I'm not able to test the 'sf' method, I think due to the issues described in #19. The 'dplyr' method works according to the examples in `st_example.R`